### PR TITLE
Update data picker button to preferences icon

### DIFF
--- a/src/definitions/telemetry/label_help.yaml
+++ b/src/definitions/telemetry/label_help.yaml
@@ -65,19 +65,19 @@ label_families:
       "Backup Power":
         help: "Points related to backup power operation, including backup mode settings and backup power availability."
 
-Type of Data:
-  help: "Categorizes the type of information the telemetry point provides."
-  labels:
-    Readings:
-      help: "Measured values reported by the equipment on-site, including voltage, current, power, and temperature."
-    Settings:
-      help: "Configuration parameters and set points that control system behavior, along with their history. These values can be adjusted on the Site Configuration page."
-    Nameplate:
-      help: "Information from equipment nameplates, such as maximum rated power output or nominal frequency."
-    Alarms/Faults:
-      help: "System alarms and faults that alert you to abnormal conditions, including hardware protection events, communication losses, configuration errors, or electrical issues."
-    Status:
-      help: "Operating states reported by the system, including mode selections, on/off indicators, and other values that show how the equipment is currently running."
+  Type of Data:
+    help: "Categorizes the type of information the telemetry point provides."
+    labels:
+      Readings:
+        help: "Measured values reported by the equipment on-site, including voltage, current, power, and temperature."
+      Settings:
+        help: "Configuration parameters and set points that control system behavior, along with their history. These values can be adjusted on the Site Configuration page."
+      Nameplate:
+        help: "Information from equipment nameplates, such as maximum rated power output or nominal frequency."
+      Alarms/Faults:
+        help: "System alarms and faults that alert you to abnormal conditions, including hardware protection events, communication losses, configuration errors, or electrical issues."
+      Status:
+        help: "Operating states reported by the system, including mode selections, on/off indicators, and other values that show how the equipment is currently running."
 
 
   Level of Detail:


### PR DESCRIPTION
…ltering

- Changed "Change Sort Order" button to "Preferences" with gear icon
- Reorganized modal to include both Sort Order and Filter Structure settings
- Added Filter Structure setting with two options:
  - Sequential (default): Filters unlock in order (Equipment → Component → Type of Data → Unit)
  - Freeform: Select filters in any order (original behavior)
- Implemented sequential filtering logic:
  - Each filter family unlocks only when previous has selections
  - Clearing a step also clears all downstream selections
  - Visual indicators for locked/unlocked states
  - Color-coded steps with selected values display
- Added explanatory text for both filter modes